### PR TITLE
Expose requires

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ lib/lexer.wasm: include-wasm/cjs-module-lexer.h src/lexer.c
 	@mkdir -p lib
 	../wasi-sdk-11.0/bin/clang src/lexer.c -I include-wasm --sysroot=../wasi-sdk-11.0/share/wasi-sysroot -o lib/lexer.wasm -nostartfiles \
 	-Wl,-z,stack-size=13312,--no-entry,--compress-relocations,--strip-all,--export=__heap_base,\
-	--export=parseCJS,--export=sa,--export=e,--export=re,--export=es,--export=ee,--export=rre,--export=ree,--export=res,--export=ree \
+	--export=parseCJS,--export=sa,--export=e,--export=re,--export=es,--export=ee,--export=rre,--export=ree,--export=res,--export=ree,--export=rrq,--export=rqs,--export=rqe \
 	-Wno-logical-op-parentheses -Wno-parentheses \
 	-Oz
 

--- a/include-wasm/cjs-module-lexer.h
+++ b/include-wasm/cjs-module-lexer.h
@@ -30,6 +30,9 @@ Slice* export_write_head = NULL;
 Slice* first_reexport = NULL;
 Slice* reexport_read_head = NULL;
 Slice* reexport_write_head = NULL;
+Slice* first_require = NULL;
+Slice* require_read_head = NULL;
+Slice* require_write_head = NULL;
 void* analysis_base;
 void* analysis_head;
 
@@ -48,6 +51,9 @@ const uint16_t* sa (uint32_t utf16Len) {
   first_reexport = NULL;
   reexport_write_head = NULL;
   reexport_read_head = NULL;
+  first_require = NULL;
+  require_write_head = NULL;
+  require_read_head = NULL;
   return source;
 }
 
@@ -72,6 +78,14 @@ uint32_t res () {
 uint32_t ree () {
   return reexport_read_head->end - source;
 }
+// getRequireStart
+uint32_t rqs () {
+  return require_read_head->start - source;
+}
+// getRequireEnd
+uint32_t rqe () {
+  return require_read_head->end - source;
+}
 // readExport
 bool re () {
   if (export_read_head == NULL)
@@ -89,6 +103,16 @@ bool rre () {
   else
     reexport_read_head = reexport_read_head->next;
   if (reexport_read_head == NULL)
+    return false;
+  return true;
+}
+// readRequire
+bool rrq () {
+  if (require_read_head == NULL)
+    require_read_head = first_require;
+  else
+    require_read_head = require_read_head->next;
+  if (require_read_head == NULL)
     return false;
   return true;
 }
@@ -119,9 +143,28 @@ void _addReexport (const uint16_t* start, const uint16_t* end) {
   reexport->end = end;
   reexport->next = NULL;
 }
+void _addRequire (const uint16_t* start, const uint16_t* end) {
+  Slice* require = (Slice*)(analysis_head);
+  analysis_head = analysis_head + sizeof(Slice);
+  if (require_write_head == NULL)
+    first_require = require;
+  else
+    require_write_head->next = require;
+  require_write_head = require;
+  require->start = start;
+  require->end = end;
+  require->next = NULL;
+}
 void (*addExport)(const uint16_t*, const uint16_t*) = &_addExport;
 void (*addReexport)(const uint16_t*, const uint16_t*) = &_addReexport;
-bool parseCJS (uint16_t* source, uint32_t sourceLen, void (*addExport)(const uint16_t* start, const uint16_t* end), void (*addReexport)(const uint16_t* start, const uint16_t* end));
+void (*addRequire)(const uint16_t*, const uint16_t*) = &_addRequire;
+bool parseCJS (
+  uint16_t* source,
+  uint32_t sourceLen,
+  void (*addExport)(const uint16_t* start, const uint16_t* end),
+  void (*addReexport)(const uint16_t* start, const uint16_t* end),
+  void (*addRequire)(const uint16_t* start, const uint16_t* end)
+);
 
 void tryBacktrackAddStarExportBinding (uint16_t* pos);
 bool tryParseRequire (bool directStarExport);

--- a/include/cjs-module-lexer.h
+++ b/include/cjs-module-lexer.h
@@ -27,7 +27,7 @@ typedef struct StarExportBinding StarExportBinding;
 
 void bail (uint32_t err);
 
-bool parseCJS (uint16_t* source, uint32_t sourceLen, void (*addExport)(const uint16_t*, const uint16_t*), void (*addReexport)(const uint16_t*, const uint16_t*));
+bool parseCJS (uint16_t* source, uint32_t sourceLen, void (*addExport)(const uint16_t*, const uint16_t*), void (*addReexport)(const uint16_t*, const uint16_t*), void (*addRequire)(const uint16_t*, const uint16_t*));
 
 void tryBacktrackAddStarExportBinding (uint16_t* pos);
 bool tryParseRequire (bool directStarExport);

--- a/lexer.js
+++ b/lexer.js
@@ -11,7 +11,8 @@ let openTokenDepth,
   starExportMap,
   lastStarExportSpecifier,
   _exports,
-  reexports;
+  reexports,
+  requires;
 
 function resetState () {
   openTokenDepth = 0;
@@ -28,6 +29,7 @@ function resetState () {
 
   _exports = new Set();
   reexports = new Set();
+  requires = [];
 }
 
 const strictReserved = new Set(['implements', 'interface', 'let', 'package', 'private', 'protected', 'public', 'static', 'yield', 'enum']);
@@ -42,7 +44,7 @@ module.exports = function parseCJS (source, name = '@') {
     e.loc = pos;
     throw e;
   }
-  const result = { exports: [..._exports], reexports: [...reexports] };
+  const result = { exports: [..._exports], reexports: [...reexports], requires };
   resetState();
   return result;
 }
@@ -645,6 +647,7 @@ function tryParseRequire (directStarExport) {
         const reexportEnd = pos++;
         ch = commentWhitespace();
         if (ch === 41/*)*/) {
+          requires.push({ s: reexportStart, e: reexportEnd });
           if (directStarExport) {
             reexports.add(source.slice(reexportStart, reexportEnd));
           }
@@ -659,6 +662,7 @@ function tryParseRequire (directStarExport) {
         const reexportEnd = pos++;
         ch = commentWhitespace();
         if (ch === 41/*)*/) {
+          requires.push({ s: reexportStart, e: reexportEnd });
           if (directStarExport) {
             reexports.add(source.slice(reexportStart, reexportEnd));
           }

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -41,15 +41,18 @@ const StarExportBinding* STAR_EXPORT_STACK_END = &starExportStack_[MAX_STAR_EXPO
 
 void (*addExport)(const uint16_t*, const uint16_t*);
 void (*addReexport)(const uint16_t*, const uint16_t*);
+void (*addRequire)(const uint16_t*, const uint16_t*);
 
 // Note: parsing is based on the _assumption_ that the source is already valid
-bool parseCJS (uint16_t* _source, uint32_t _sourceLen, void (*_addExport)(const uint16_t*, const uint16_t*), void (*_addReexport)(const uint16_t*, const uint16_t*)) {
+bool parseCJS (uint16_t* _source, uint32_t _sourceLen, void (*_addExport)(const uint16_t*, const uint16_t*), void (*_addReexport)(const uint16_t*, const uint16_t*), void (*_addRequire)(const uint16_t*, const uint16_t*)) {
   source = _source;
   sourceLen = _sourceLen;
   if (_addExport)
     addExport = _addExport;
   if (_addReexport)
     addReexport = _addReexport;
+  if (_addRequire)
+    addRequire = _addRequire;
 
   templateStackDepth = 0;
   openTokenDepth = 0;
@@ -669,6 +672,7 @@ bool tryParseRequire (bool directStarExport) {
         uint16_t* reexportEnd = pos++;
         ch = commentWhitespace();
         if (ch == ')') {
+          addRequire(reexportStart, reexportEnd);
           if (directStarExport) {
             addReexport(reexportStart, reexportEnd);
           }
@@ -684,6 +688,7 @@ bool tryParseRequire (bool directStarExport) {
         uint16_t* reexportEnd = pos++;
         ch = commentWhitespace();
         if (ch == ')') {
+          addRequire(reexportStart, reexportEnd);
           if (directStarExport) {
             addReexport(reexportStart, reexportEnd);
           }

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -17,7 +17,7 @@ export function parse (source, name = '@') {
   if (!wasm.parseCJS(addr, source.length, 0, 0))
     throw Object.assign(new Error(`Parse error ${name}${wasm.e()}:${source.slice(0, wasm.e()).split('\n').length}:${wasm.e() - source.lastIndexOf('\n', wasm.e() - 1)}`), { idx: wasm.e() });
 
-  let exports = new Set(), reexports = new Set();
+  let exports = new Set(), reexports = new Set(), requires = [];
   while (wasm.rre())
     reexports.add(source.slice(wasm.res(), wasm.ree()));
   while (wasm.re()) {
@@ -25,8 +25,10 @@ export function parse (source, name = '@') {
     if (!strictReserved.has(exptStr))
       exports.add(exptStr);
   }
+  while (wasm.rrq())
+    requires.push({ s: wasm.rqs(), e: wasm.rqe() });
 
-  return { exports: [...exports], reexports: [...reexports] };
+  return { exports: [...exports], reexports: [...reexports], requires };
 }
 
 function copy (src, outBuf16) {

--- a/test/_unit.js
+++ b/test/_unit.js
@@ -428,6 +428,25 @@ suite('Lexer', () => {
     assert.equal(reexports[1], './another');
   });
 
+
+  test('Requires', () => {
+    const source = `
+      const a = require("module/a");
+      const b = require("./module-b.js");
+    `;
+    const { exports, reexports, requires } = parse(source);
+    assert.equal(requires.length, 2);
+
+    assert.deepEqual(requires[0], { s: 26, e: 34 });
+    assert.equal(source.slice(requires[0].s, requires[0].e), `module/a`);
+
+    assert.deepEqual(requires[1], { s: 63, e: 76 });
+    assert.equal(source.slice(requires[1].s, requires[1].e), `./module-b.js`);
+
+    assert.equal(exports.length, 0);
+    assert.equal(reexports.length, 0);
+  });
+
   test('Single parse cases', () => {
     parse(`'asdf'`);
     parse(`/asdf/`);


### PR DESCRIPTION
This adds a third `requires[]` property to the output object in both modes. It's an Array of `{s:number,e:number}` start/end offsets, like those of `es-module-lexer`. All require() calls, including re-exports, are added to the Array.

```js
const source = `foo=require("foo")`;
const { requires } = parse(source);
requires; // [{ s: 13, e: 16 }]
source.substring(requires[0].s, requires[0].e);  // foo
```