### PR TITLE
Only include last reexport assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ EXPORT_STAR_LIB: `Object.keys(` IDENTIFIER$1 `).forEach(function (` IDENTIFIER$2
 ```
 
 * The returned export names are the matched `IDENTIFIER` and `IDENTIFIER_STRING` slots for all `EXPORTS_MEMBER`, `EXPORTS_DEFINE` and `EXPORTS_LITERAL` matches.
-* The reexport specifiers are taken to be the `STRING_LITERAL` slots of all `MODULE_EXPORTS_ASSIGN` as well as all _top-level_ `EXPORT_STAR` `REQUIRE` matches and `EXPORTS_ASSIGN` matches whose `IDENTIFIER` also matches the first `IDENTIFIER` in `EXPORT_STAR_LIB`.
+* The reexport specifiers are taken to be the `STRING_LITERAL` slot of the last `MODULE_EXPORTS_ASSIGN` as well as all _top-level_ `EXPORT_STAR` `REQUIRE` matches and `EXPORTS_ASSIGN` matches whose `IDENTIFIER` also matches the first `IDENTIFIER` in `EXPORT_STAR_LIB`.
 
 ### Parsing Examples
 
@@ -180,16 +180,16 @@ module.exports = {
 
 #### module.exports reexport assignment
 
-Any `module.exports = require('mod')` assignment is detected as a reexport:
+Any `module.exports = require('mod')` assignment is detected as a reexport, but only the last one is returned:
 
 ```js
-// DETECTS REEXPORTS: a, b, c
+// DETECTS REEXPORTS: c
 module.exports = require('a');
 (module => module.exports = require('b'))(NOT_MODULE);
 if (false) module.exports = require('c');
 ```
 
-As a result, the total list of exports would be inferred as the union of all of these reexported modules, which can lead to possible over-classification.
+This is to avoid overclassification in Webpack bundles with externals which include `module.exports = require('external')` in their source for every external dependency.
 
 #### Transpiler Re-exports
 

--- a/include-wasm/cjs-module-lexer.h
+++ b/include-wasm/cjs-module-lexer.h
@@ -123,8 +123,14 @@ void (*addExport)(const uint16_t*, const uint16_t*) = &_addExport;
 void (*addReexport)(const uint16_t*, const uint16_t*) = &_addReexport;
 bool parseCJS (uint16_t* source, uint32_t sourceLen, void (*addExport)(const uint16_t* start, const uint16_t* end), void (*addReexport)(const uint16_t* start, const uint16_t* end));
 
+enum RequireType {
+  Import,
+  ExportAssign,
+  ExportStar
+};
+
 void tryBacktrackAddStarExportBinding (uint16_t* pos);
-bool tryParseRequire (bool directStarExport);
+bool tryParseRequire (enum RequireType requireType);
 void tryParseLiteralExports ();
 bool readExportsOrModuleDotExports (uint16_t ch);
 void tryParseModuleExportsDotAssign ();

--- a/include/cjs-module-lexer.h
+++ b/include/cjs-module-lexer.h
@@ -29,8 +29,14 @@ void bail (uint32_t err);
 
 bool parseCJS (uint16_t* source, uint32_t sourceLen, void (*addExport)(const uint16_t*, const uint16_t*), void (*addReexport)(const uint16_t*, const uint16_t*));
 
+enum RequireType {
+  Import,
+  ExportAssign,
+  ExportStar
+};
+
 void tryBacktrackAddStarExportBinding (uint16_t* pos);
-bool tryParseRequire (bool directStarExport);
+bool tryParseRequire (enum RequireType requireType);
 void tryParseLiteralExports ();
 bool readExportsOrModuleDotExports (uint16_t ch);
 void tryParseModuleExportsDotAssign ();

--- a/test/_unit.js
+++ b/test/_unit.js
@@ -423,9 +423,8 @@ suite('Lexer', () => {
     `);
     assert.equal(exports.length, 1);
     assert.equal(exports[0], 'asdf');
-    assert.equal(reexports.length, 2);
-    assert.equal(reexports[0], './asdf');
-    assert.equal(reexports[1], './another');
+    assert.equal(reexports.length, 1);
+    assert.equal(reexports[0], './another');
   });
 
   test('Single parse cases', () => {


### PR DESCRIPTION
This updates the reexport detection to only handle the last reexport assignment.

For example:

```js
module.exports = require('a');
module.exports = require('b');
```

before this PR would return `a`, `b`, and after this PR would return just `b`.

The rationale here is that Webpack bundles include `module.exports = require('external')` for every single external they import from, when those aren't actually reexports. This saves unnecessary work and overclassification in those cases, with what doesn't seem to be too much of a loss.