### PR TITLE
Replace endian specific copy functions with DataView

### DIFF
--- a/src/lexer.js
+++ b/src/lexer.js
@@ -2,21 +2,20 @@ const strictReserved = new Set(['implements', 'interface', 'let', 'package', 'pr
 
 let wasm;
 
-const isLE = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
-
 export function parse (source, name = '@') {
   if (!wasm)
     throw new Error('Not initialized');
 
   const len = source.length + 1;
+  const byteLength = len * 2;
 
   // need 2 bytes per code point plus analysis space so we double again
   const extraMem = (wasm.__heap_base.value || wasm.__heap_base) + len * 4 - wasm.memory.buffer.byteLength;
   if (extraMem > 0)
     wasm.memory.grow(Math.ceil(extraMem / 65536));
     
-  const addr = wasm.sa(len);
-  (isLE ? copyLE : copyBE)(source, new Uint16Array(wasm.memory.buffer, addr, len));
+  const addr = wasm.sa(byteLength);
+  copy(source, new DataView(wasm.memory.buffer, addr, byteLength));
 
   if (!wasm.parseCJS(addr, source.length, 0, 0))
     throw Object.assign(new Error(`Parse error ${name}${wasm.e()}:${source.slice(0, wasm.e()).split('\n').length}:${wasm.e() - source.lastIndexOf('\n', wasm.e() - 1)}`), { idx: wasm.e() });
@@ -33,20 +32,11 @@ export function parse (source, name = '@') {
   return { exports: [...exports], reexports: [...reexports] };
 }
 
-function copyBE (src, outBuf16) {
-  const len = src.length;
-  let i = 0;
-  while (i < len) {
-    const ch = src.charCodeAt(i);
-    outBuf16[i++] = (ch & 0xff) << 8 | ch >>> 8;
-  }
-}
-
-function copyLE (src, outBuf16) {
+function copy (src, outBuf16) {
   const len = src.length;
   let i = 0;
   while (i < len)
-    outBuf16[i] = src.charCodeAt(i++);
+    outBuf16.setUint16(i * 2, src.charCodeAt(i++), true);
 }
 
 let initPromise;


### PR DESCRIPTION
Refs: https://github.com/guybedford/cjs-module-lexer/pull/13#discussion_r504212110

@guybedford This is the tidied up version of the hack I did to get the tests passing on AIX (big endian). I'm okay with https://github.com/guybedford/cjs-module-lexer/pull/13 so am not fussed if this lands or is just closed out, but I've opened it anyway as an FYI. 

FWIW the original hack kept the `copyBE` and `copyLE` functions and only used `DataView` for `copyBE`. It was hacky because it took me a while to realise that the source length was in characters and DataView's length/offsets were in bytes.