### PR TITLE
Support reexports via require spreads

### DIFF
--- a/include-wasm/cjs-module-lexer.h
+++ b/include-wasm/cjs-module-lexer.h
@@ -119,9 +119,14 @@ void _addReexport (const uint16_t* start, const uint16_t* end) {
   reexport->end = end;
   reexport->next = NULL;
 }
+void _clearReexports () {
+  reexport_write_head = NULL;
+  first_reexport = NULL;
+}
 void (*addExport)(const uint16_t*, const uint16_t*) = &_addExport;
 void (*addReexport)(const uint16_t*, const uint16_t*) = &_addReexport;
-bool parseCJS (uint16_t* source, uint32_t sourceLen, void (*addExport)(const uint16_t* start, const uint16_t* end), void (*addReexport)(const uint16_t* start, const uint16_t* end));
+void (*clearReexports)() = &_clearReexports;
+bool parseCJS (uint16_t* source, uint32_t sourceLen, void (*addExport)(const uint16_t* start, const uint16_t* end), void (*addReexport)(const uint16_t* start, const uint16_t* end), void (*clearReexports)());
 
 enum RequireType {
   Import,

--- a/include/cjs-module-lexer.h
+++ b/include/cjs-module-lexer.h
@@ -27,7 +27,7 @@ typedef struct StarExportBinding StarExportBinding;
 
 void bail (uint32_t err);
 
-bool parseCJS (uint16_t* source, uint32_t sourceLen, void (*addExport)(const uint16_t*, const uint16_t*), void (*addReexport)(const uint16_t*, const uint16_t*));
+bool parseCJS (uint16_t* source, uint32_t sourceLen, void (*addExport)(const uint16_t*, const uint16_t*), void (*addReexport)(const uint16_t*, const uint16_t*), void (*clearReexports)());
 
 enum RequireType {
   Import,

--- a/test/_unit.js
+++ b/test/_unit.js
@@ -234,6 +234,25 @@ suite('Lexer', () => {
     assert.equal(exports.length, 0);
   });
 
+  test('module exports reexport spread', () => {
+    const { exports, reexports } = parse(`
+      module.exports = {
+        ...a,
+        ...b,
+        ...require('dep1'),
+        c: d,
+        ...require('dep2'),
+        name
+      };
+    `);
+    assert.equal(exports.length, 2);
+    assert.equal(exports[0], 'c');
+    assert.equal(exports[1], 'name');
+    assert.equal(reexports.length, 2);
+    assert.equal(reexports[0], 'dep1');
+    assert.equal(reexports[1], 'dep2');
+  });
+
   test('Regexp case', () => {
     parse(`
       class Number {


### PR DESCRIPTION
This adds support for require spreads in reexports which came up in https://github.com/facebook/jest/issues/9430#issuecomment-713204282, like:

```js
module.exports = {
  ...require('a'),
  ...require('b')
};
```

This is just the JS implementation for now, I will add the Wasm implementation shortly.

//cc @jkrems for review.