### PR TITLE
Handle yield ambiguity

### DIFF
--- a/lexer.js
+++ b/lexer.js
@@ -1126,9 +1126,6 @@ function isExpressionKeyword (pos) {
         case 105/*i*/:
           // void
           return readPrecedingKeyword(pos - 2, 'vo');
-        case 108/*l*/:
-          // yield
-          return readPrecedingKeyword(pos - 2, 'yie');
         default:
           return false;
       }

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1214,9 +1214,6 @@ bool isExpressionKeyword (uint16_t* pos) {
         case 'i':
           // void
           return readPrecedingKeyword2(pos - 2, 'v', 'o');
-        case 'l':
-          // yield
-          return readPrecedingKeyword3(pos - 2, 'y', 'i', 'e');
         default:
           return false;
       }

--- a/test/_unit.js
+++ b/test/_unit.js
@@ -660,4 +660,19 @@ function x() {
     assert.ok(exports[0] === 'a');
     assert.ok(exports[1] === 'b');
   });
+
+  test('Yield ambiguity case', () => {
+    var { exports, reexports } = parse(`
+      function* fn() {
+        yield / "/ //" /*
+      }
+      /*/
+      }
+      
+      module.exports.foo = 2;
+      
+      // */
+    `);
+    assert.equal(exports.length, 1);
+  });
 });


### PR DESCRIPTION
This removes `"yield"` from the list of expression keywords that cause regex parsing, as posted in https://github.com/guybedford/cjs-module-lexer/issues/20.

Per discussion there this is a non-real-world parsing case that likely has never been written by anyone anywhere before :P