### PR TITLE
Handle void object case

### DIFF
--- a/lexer.js
+++ b/lexer.js
@@ -1214,7 +1214,7 @@ function isExpressionPunctuator (ch) {
 
 function isExpressionTerminator (curPos) {
   // detects:
-  // => ; ) finally catch else
+  // => ; ) finally catch else void
   // as all of these followed by a { will indicate a statement brace
   switch (source.charCodeAt(curPos)) {
     case 62/*>*/:
@@ -1228,6 +1228,8 @@ function isExpressionTerminator (curPos) {
       return source.startsWith('finall', curPos - 6);
     case 101/*e*/:
       return source.startsWith('els', curPos - 3);
+    case 100/*d*/:
+      return source.startsWith('voi', curPos - 3);
   }
   return false;
 }

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1302,7 +1302,7 @@ bool isExpressionPunctuator (uint16_t ch) {
 
 bool isExpressionTerminator (uint16_t* curPos) {
   // detects:
-  // > ; ) -1 finally catch
+  // > ; ) -1 finally catch void
   // as all of these followed by a { will indicate a statement brace
   switch (*curPos) {
     case '>':
@@ -1316,6 +1316,8 @@ bool isExpressionTerminator (uint16_t* curPos) {
       return readPrecedingKeyword6(curPos - 1, 'f', 'i', 'n', 'a', 'l', 'l');
     case 'e':
       return readPrecedingKeyword3(curPos - 1, 'e', 'l', 's');
+    case 'd':
+      return readPrecedingKeyword3(curPos - 1, 'v', 'o', 'i');
   }
   return false;
 }

--- a/test/_unit.js
+++ b/test/_unit.js
@@ -645,6 +645,21 @@ function x() {
     assert.ok(parse(source));
   });
 
+  test('Void case', () => {
+    var { exports } = parse(`
+      void {
+        x: []
+      } / "/ //" /*
+
+      /*/
+
+      module.exports.foo = 2;
+
+      // */
+    `);
+    assert.equal(exports.length, 0);
+  });
+
   test('Template string expression ambiguity', () => {
     const source = `
       \`$\`


### PR DESCRIPTION
This adds `void` to the list of `{` prefix tokens that imply block statement braces.

Fixes https://github.com/guybedford/cjs-module-lexer/issues/22.

Again, these are academic edge cases, and don't affect real world code.