### PR TITLE
Do not emit Object.defineProperty exports

### DIFF
--- a/lexer.js
+++ b/lexer.js
@@ -278,7 +278,9 @@ function tryParseObjectDefineOrKeys (keys) {
             const exportPos = ++pos;
             if (identifier() && source.charCodeAt(pos) === ch) {
               // revert for "("
-              addExport(source.slice(exportPos, pos));
+              const expt = source.slice(exportPos, pos);
+              if (expt === '__esModule')
+                addExport(expt);
             }
           }
         }

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -290,7 +290,8 @@ void tryParseObjectDefineOrKeys (bool keys) {
             uint16_t* exportPos = ++pos;
             if (identifier(*pos) && *pos == ch) {
               // revert for "("
-              addExport(exportPos, pos);
+              if (pos - exportPos == 10 && str_eq10(exportPos, '_', '_', 'e', 's', 'M', 'o', 'd', 'u', 'l', 'e'))
+                addExport(exportPos, pos);
             }
           }
         }

--- a/test/_unit.js
+++ b/test/_unit.js
@@ -453,10 +453,8 @@ suite('Lexer', () => {
       Object.defineProperty(module.exports, 'thing', { value: true });
       Object.defineProperty(exports, "__esModule", { value: true });
     `);
-    assert.equal(exports.length, 3);
-    assert.equal(exports[0], 'namedExport');
-    assert.equal(exports[1], 'thing');
-    assert.equal(exports[2], '__esModule');
+    assert.equal(exports.length, 1);
+    assert.equal(exports[0], '__esModule');
   });
 
   test('module assign', () => {


### PR DESCRIPTION
This disables the emission of arbotrary `Object.defineProperty` exports, to fix the issue posted in https://github.com/nodejs/node/issues/35859.

`__esModule` detection is handled as an exception only.