### PR TITLE
Support specific getter forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ EXPORTS_DEFINE: `Object` `.` `defineProperty `(` IDENTIFIER_STRING `, {`
     `value:` |
     `get:` `function`? `()` {` return IDENTIFIER (`.` IDENTIFIER | `[` IDENTIFIER_STRING `]`)? `;`? `}`
   )
+  `})`
 
 EXPORTS_LITERAL: MODULE_EXPORTS `=` `{` (EXPORTS_LITERAL_PROP | EXPORTS_SPREAD) `,`)+ `}`
 
@@ -187,20 +188,35 @@ Object.defineProperty(exports, 'd', { value: 'd' });
 Object.defineProperty(exports, '__esModule', { value: true });
 ```
 
-Dynamic getter functions that do not return a direct identifier or member expression are not detected:
+Other getter structurs or not return a direct identifier or member expression are not detected:
 
 ```js
 // DETECTS: NO EXPORTS
 Object.defineProperty(exports, 'a', {
+  enumerable: false,
+  get () {
+    return p;
+  }
+});
+Object.defineProperty(exports, 'b', {
+  configurable: true,
+  get () {
+    return p;
+  }
+});
+Object.defineProperty(exports, 'c', {
+  get: () => p
+});
+Object.defineProperty(exports, 'd', {
   enumerable: true,
   get: function () {
     return dynamic();
   }
 });
-Object.defineProperty(exports, 'b', {
+Object.defineProperty(exports, 'e', {
   enumerable: true,
   get () {
-    return 'nope';
+    return 'str';
   }
 });
 ```

--- a/README.md
+++ b/README.md
@@ -160,8 +160,6 @@ It will in turn underclassify in cases where the identifiers are renamed:
 })(exports);
 ```
 
-#### Exports Getters
-
 `Object.defineProperty` is detected for any usage of the `__esModule` export, as well as the specific value and getter forms:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Spacing between tokens is taken to be any ECMA-262 whitespace, ECMA-262 block co
 
 #### Named Exports Parsing
 
-The basic matching rules for named exports are `exports.name` and `exports['name']`. This matching is done without scope analysis and regardless of the expression position:
+The basic matching rules for named exports are `exports.name`, `exports['name']` or `Object.defineProperty(exports, 'name', ...)`. This matching is done without scope analysis and regardless of the expression position:
 
 ```js
 // DETECTS EXPORTS: a, b

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ It will in turn underclassify in cases where the identifiers are renamed:
 })(exports);
 ```
 
-`Object.defineProperty` is detected for any usage of the `__esModule` export, as well as the specific value and getter forms:
+`Object.defineProperty` is detected for specifically value and getter forms returning an identifier or member expression:
 
 ```js
 // DETECTS: a, b, c, d, __esModule
@@ -186,7 +186,7 @@ Object.defineProperty(exports, 'd', { value: 'd' });
 Object.defineProperty(exports, '__esModule', { value: true });
 ```
 
-Other getter structurs or not return a direct identifier or member expression are not detected:
+Alternative object definition structures or getter function bodies are not detected:
 
 ```js
 // DETECTS: NO EXPORTS

--- a/lexer.js
+++ b/lexer.js
@@ -260,30 +260,116 @@ function tryParseObjectDefineOrKeys (keys) {
     pos++;
     ch = commentWhitespace();
     if (ch === 100/*d*/ && source.startsWith('efineProperty', pos + 1)) {
-      pos += 14;
-      revertPos = pos - 1;
-      ch = commentWhitespace();
-      if (ch !== 40/*(*/) {
-        pos = revertPos;
-        return;
-      }
-      pos++;
-      ch = commentWhitespace();
-      if (readExportsOrModuleDotExports(ch)) {
+      while (true) {
+        pos += 14;
+        revertPos = pos - 1;
         ch = commentWhitespace();
-        if (ch === 44/*,*/) {
+        if (ch !== 40/*(*/) break;
+        pos++;
+        ch = commentWhitespace();
+        if (!readExportsOrModuleDotExports(ch)) break;
+        ch = commentWhitespace();
+        if (ch !== 44/*,*/) break;
+        pos++;
+        ch = commentWhitespace();
+        if (ch !== 39/*'*/ && ch !== 34/*"*/) break;
+        let quot = ch;
+        const exportPos = ++pos;
+        if (!identifier() || source.charCodeAt(pos) !== ch) break;
+        // revert for "("
+        const expt = source.slice(exportPos, pos);
+        if (source.charCodeAt(pos) !== quot) break;
+        pos++;
+        ch = commentWhitespace();
+        if (ch !== 44/*,*/) break;
+        pos++;
+        ch = commentWhitespace();
+        if (ch !== 123/*{*/) break;
+        pos++;
+        ch = commentWhitespace();
+        if (ch === 101/*e*/) {
+          if (!source.startsWith('numerable', pos + 1)) break;
+          pos += 10;
+          ch = commentWhitespace();
+          if (ch !== 58/*:*/) break;
           pos++;
           ch = commentWhitespace();
-          if (ch === 39/*'*/ || ch === 34/*"*/) {
-            const exportPos = ++pos;
-            if (identifier() && source.charCodeAt(pos) === ch) {
-              // revert for "("
-              const expt = source.slice(exportPos, pos);
-              if (expt === '__esModule')
-                addExport(expt);
-            }
-          }
+          if (ch !== 116/*t*/ || !source.startsWith('rue', pos + 1)) break;
+          pos += 4;
+          ch = commentWhitespace();
+          if (ch !== 44) break;
+          pos++;
+          ch = commentWhitespace();
         }
+        if (ch === 118/*v*/) {
+          if (!source.startsWith('alue', pos + 1)) break;
+          pos += 5;
+          ch = commentWhitespace();
+          if (ch !== 58/*:*/) break;
+          pos++;
+          addExport(expt);
+          break;
+        }
+        else if (ch === 103/*g*/) {
+          if (!source.startsWith('et', pos + 1)) break;
+          pos += 3;
+          ch = commentWhitespace();
+          if (ch === 58/*:*/) {
+            pos++;
+            ch = commentWhitespace();
+            if (ch !== 102/*f*/) break;
+            if (!source.startsWith('unction', pos + 1)) break;
+            pos += 8;
+            ch = commentWhitespace();
+          }
+          if (ch !== 40/*(*/) break;
+          pos++;
+          ch = commentWhitespace();
+          if (ch !== 41/*)*/) break;
+          pos++;
+          ch = commentWhitespace();
+          if (ch !== 123/*{*/) break;
+          pos++;
+          ch = commentWhitespace();
+          if (ch !== 114/*r*/) break;
+          if (!source.startsWith('eturn', pos + 1)) break;
+          pos += 6;
+          ch = commentWhitespace();
+          if (!identifier()) break;
+          ch = commentWhitespace();
+          if (ch === 46/*.*/) {
+            pos++;
+            commentWhitespace();
+            if (!identifier()) break;
+            ch = commentWhitespace();
+          }
+          else if (ch === 91/*[*/) {
+            pos++;
+            ch = commentWhitespace();
+            if (ch === 39/*'*/) singleQuoteString();
+            else if (ch === 34/*"*/) doubleQuoteString();
+            else break;
+            pos++;
+            ch = commentWhitespace();
+            if (ch !== 93/*]*/) break;
+            pos++;
+            ch = commentWhitespace();
+          }
+          if (ch === 59/*;*/) {
+            pos++;
+            ch = commentWhitespace();
+          }
+          if (ch !== 125/*}*/) break;
+          addExport(expt);
+          pos++;
+          ch = commentWhitespace();
+          if (ch !== 125/*}*/) break;
+          pos++;
+          ch = commentWhitespace();
+          if (ch !== 41/*)*/) break;
+          return;
+        }
+        break;
       }
     }
     else if (keys && ch === 107/*k*/ && source.startsWith('eys', pos + 1)) {

--- a/lexer.js
+++ b/lexer.js
@@ -275,10 +275,8 @@ function tryParseObjectDefineOrKeys (keys) {
         if (ch !== 39/*'*/ && ch !== 34/*"*/) break;
         let quot = ch;
         const exportPos = ++pos;
-        if (!identifier() || source.charCodeAt(pos) !== ch) break;
-        // revert for "("
+        if (!identifier() || source.charCodeAt(pos) !== quot) break;
         const expt = source.slice(exportPos, pos);
-        if (source.charCodeAt(pos) !== quot) break;
         pos++;
         ch = commentWhitespace();
         if (ch !== 44/*,*/) break;
@@ -360,13 +358,13 @@ function tryParseObjectDefineOrKeys (keys) {
             ch = commentWhitespace();
           }
           if (ch !== 125/*}*/) break;
-          addExport(expt);
           pos++;
           ch = commentWhitespace();
           if (ch !== 125/*}*/) break;
           pos++;
           ch = commentWhitespace();
           if (ch !== 41/*)*/) break;
+          addExport(expt);
           return;
         }
         break;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -272,29 +272,118 @@ void tryParseObjectDefineOrKeys (bool keys) {
     pos++;
     ch = commentWhitespace();
     if (ch == 'd' && str_eq13(pos + 1, 'e', 'f', 'i', 'n', 'e', 'P', 'r', 'o', 'p', 'e', 'r', 't', 'y')) {
-      pos += 14;
-      revertPos = pos - 1;
-      ch = commentWhitespace();
-      if (ch != '(') {
-        pos = revertPos;
-        return;
-      }
-      pos++;
-      ch = commentWhitespace();
-      if (readExportsOrModuleDotExports(ch)) {
+      while (true) {
+        pos += 14;
+        revertPos = pos - 1;
         ch = commentWhitespace();
-        if (ch == ',') {
+        if (ch != '(') break;
+        pos++;
+        ch = commentWhitespace();
+        if (!readExportsOrModuleDotExports(ch)) break;
+        ch = commentWhitespace();
+        if (ch != ',') break;
+        pos++;
+        ch = commentWhitespace();
+        if (ch != '\'' && ch != '"') break;
+        uint16_t quot = ch;
+        uint16_t* exportStart = ++pos;
+        if (!identifier(*pos) || *pos != quot) break;
+        uint16_t* exportEnd = pos;
+        pos++;
+        ch = commentWhitespace();
+        if (ch != ',') break;
+        pos++;
+        ch = commentWhitespace();
+        if (ch != '{') break;
+        pos++;
+        ch = commentWhitespace();
+        if (ch == 'e') {
+          if (!str_eq9(pos + 1, 'n', 'u', 'm', 'e', 'r', 'a', 'b', 'l', 'e')) break;
+          pos += 10;
+          ch = commentWhitespace();
+          if (ch != ':') break;
           pos++;
           ch = commentWhitespace();
-          if (ch == '\'' || ch == '"') {
-            uint16_t* exportPos = ++pos;
-            if (identifier(*pos) && *pos == ch) {
-              // revert for "("
-              if (pos - exportPos == 10 && str_eq10(exportPos, '_', '_', 'e', 's', 'M', 'o', 'd', 'u', 'l', 'e'))
-                addExport(exportPos, pos);
-            }
-          }
+          if (ch != 't' || !str_eq3(pos + 1, 'r', 'u', 'e')) break;
+          pos += 4;
+          ch = commentWhitespace();
+          if (ch != 44) break;
+          pos++;
+          ch = commentWhitespace();
         }
+        if (ch == 'v') {
+          if (!str_eq4(pos + 1, 'a', 'l', 'u', 'e')) break;
+          pos += 5;
+          ch = commentWhitespace();
+          if (ch != ':') break;
+          pos++;
+          addExport(exportStart, exportEnd);
+          break;
+        }
+        else if (ch == 'g') {
+          if (!str_eq2(pos + 1, 'e', 't')) break;
+          pos += 3;
+          ch = commentWhitespace();
+          if (ch == ':') {
+            pos++;
+            ch = commentWhitespace();
+            if (ch != 'f') break;
+            if (!str_eq7(pos + 1, 'u', 'n', 'c', 't', 'i', 'o', 'n')) break;
+            pos += 8;
+            ch = commentWhitespace();
+          }
+          if (ch != '(') break;
+          pos++;
+          ch = commentWhitespace();
+          if (ch != ')') break;
+          pos++;
+          ch = commentWhitespace();
+          if (ch != '{') break;
+          pos++;
+          ch = commentWhitespace();
+          if (ch != 'r') break;
+          if (!str_eq5(pos + 1, 'e', 't', 'u', 'r', 'n')) break;
+          pos += 6;
+          ch = commentWhitespace();
+          if (!identifier(ch)) break;
+          ch = commentWhitespace();
+          if (ch == '.') {
+            pos++;
+            ch = commentWhitespace();
+            if (!identifier(ch)) break;
+            ch = commentWhitespace();
+          }
+          else if (ch == '[') {
+            pos++;
+            ch = commentWhitespace();
+            if (ch == '\'') singleQuoteString();
+            else if (ch == '"') doubleQuoteString();
+            else break;
+            pos++;
+            ch = commentWhitespace();
+            if (ch != ']') break;
+            pos++;
+            ch = commentWhitespace();
+          }
+          if (ch == ';') {
+            pos++;
+            ch = commentWhitespace();
+          }
+          if (ch != '}') break;
+          if (ch == ',') {
+            pos++;
+            ch = commentWhitespace();
+          }
+          pos++;
+          ch = commentWhitespace();
+          if (ch != '}') break;
+          pos++;
+          ch = commentWhitespace();
+          if (ch != ')') break;
+          addExport(exportStart, exportEnd);
+          return;
+        }
+        break;
       }
     }
     else if (keys && ch == 'k' && str_eq3(pos + 1, 'e', 'y', 's')) {

--- a/test/_unit.js
+++ b/test/_unit.js
@@ -64,11 +64,18 @@ suite('Lexer', () => {
           return __ns.val;
         }
       });
+
+      Object.defineProperty(exports, 'e', {
+        get () {
+          return external;
+        }
+      });
     `);
-    assert.equal(exports.length, 3);
+    assert.equal(exports.length, 4);
     assert.equal(exports[0], 'a');
     assert.equal(exports[1], 'c');
     assert.equal(exports[2], 'd');
+    assert.equal(exports[3], 'e');
   });
 
   test('Rollup Babel reexports', () => {
@@ -484,6 +491,36 @@ suite('Lexer', () => {
   test('defineProperty value', () => {
     const { exports } = parse(`
       Object.defineProperty(exports, 'namedExport', { enumerable: false, value: true });
+      Object.defineProperty(exports, 'namedExport', { configurable: false, value: true });
+
+      Object.defineProperty(exports, 'a', {
+        enumerable: false,
+        get () {
+          return p;
+        }
+      });
+      Object.defineProperty(exports, 'b', {
+        configurable: true,
+        get () {
+          return p;
+        }
+      });
+      Object.defineProperty(exports, 'c', {
+        get: () => p
+      });
+      Object.defineProperty(exports, 'd', {
+        enumerable: true,
+        get: function () {
+          return dynamic();
+        }
+      });
+      Object.defineProperty(exports, 'e', {
+        enumerable: true,
+        get () {
+          return 'str';
+        }
+      });
+
       Object.defineProperty(module.exports, 'thing', { value: true });
       Object.defineProperty(exports, "other", { enumerable: true, value: true });
       Object.defineProperty(exports, "__esModule", { value: true });

--- a/test/_unit.js
+++ b/test/_unit.js
@@ -37,6 +37,40 @@ suite('Lexer', () => {
     assert.equal(reexports[3], 'external4');
   });
 
+  test('Rollup Babel reexport getter', () => {
+    var { exports } = parse(`
+      Object.defineProperty(exports, 'a', {
+        enumerable: true,
+        get: function () {
+          return q.p;
+        }
+      });
+
+      Object.defineProperty(exports, 'b', {
+        enumerable: false,
+        get: function () {
+          return q.p;
+        }
+      });
+
+      Object.defineProperty(exports, "c", {
+        get: function () {
+          return q['p' ];
+        }
+      });
+
+      Object.defineProperty(exports, 'd', {
+        get: function () {
+          return __ns.val;
+        }
+      });
+    `);
+    assert.equal(exports.length, 3);
+    assert.equal(exports[0], 'a');
+    assert.equal(exports[1], 'c');
+    assert.equal(exports[2], 'd');
+  });
+
   test('Rollup Babel reexports', () => {
     var { exports, reexports } = parse(`
       "use strict";
@@ -447,14 +481,17 @@ suite('Lexer', () => {
     assert.equal(exports[1], 'Tokenizer');
   });
 
-  test('defineProperty', () => {
+  test('defineProperty value', () => {
     const { exports } = parse(`
-      Object.defineProperty(exports, 'namedExport', { value: true });
+      Object.defineProperty(exports, 'namedExport', { enumerable: false, value: true });
       Object.defineProperty(module.exports, 'thing', { value: true });
+      Object.defineProperty(exports, "other", { enumerable: true, value: true });
       Object.defineProperty(exports, "__esModule", { value: true });
     `);
-    assert.equal(exports.length, 1);
-    assert.equal(exports[0], '__esModule');
+    assert.equal(exports.length, 3);
+    assert.equal(exports[0], 'thing');
+    assert.equal(exports[1], 'other');
+    assert.equal(exports[2], '__esModule');
   });
 
   test('module assign', () => {


### PR DESCRIPTION
As a follow up to the deprecation in https://github.com/guybedford/cjs-module-lexer/pull/24, this is breaking some Babel strict mode outputs that use getters for named exports.

Instead, this PR detects very specific getter forms that are the common cases of a value definition or a getter returning either an identifier or a member expression only.

The Wasm implementation update here is still pending, but the grammar and initial tests are in place for review.

//cc @targos @nicolo-ribaudo @bmeck if any of you are interested in review here.