### PR TITLE
Support getter function name in reexports

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ EXPORTS_DEFINE: `Object` `.` `defineProperty `(` IDENTIFIER_STRING `, {`
   (`enumerable: true,`)?
   (
     `value:` |
-    `get` `: function`? `()` {` return IDENTIFIER (`.` IDENTIFIER | `[` IDENTIFIER_STRING `]`)? `;`? `}`
+    `get` (`: function` IDENTIFIER? )?  `()` {` return IDENTIFIER (`.` IDENTIFIER | `[` IDENTIFIER_STRING `]`)? `;`? `}`
   )
   `})`
 

--- a/lexer.js
+++ b/lexer.js
@@ -318,6 +318,9 @@ function tryParseObjectDefineOrKeys (keys) {
             if (ch !== 102/*f*/) break;
             if (!source.startsWith('unction', pos + 1)) break;
             pos += 8;
+            let lastPos = pos;
+            ch = commentWhitespace();
+            if (ch !== 40 && (lastPos === pos || !identifier())) break;
             ch = commentWhitespace();
           }
           if (ch !== 40/*(*/) break;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -330,6 +330,9 @@ void tryParseObjectDefineOrKeys (bool keys) {
             if (ch != 'f') break;
             if (!str_eq7(pos + 1, 'u', 'n', 'c', 't', 'i', 'o', 'n')) break;
             pos += 8;
+            uint16_t* lastPos = pos;
+            ch = commentWhitespace();
+            if (ch != '(' && (lastPos == pos || !identifier(ch))) break;
             ch = commentWhitespace();
           }
           if (ch != '(') break;

--- a/test/_unit.js
+++ b/test/_unit.js
@@ -54,7 +54,7 @@ suite('Lexer', () => {
       });
 
       Object.defineProperty(exports, "c", {
-        get: function () {
+        get: function get () {
           return q['p' ];
         }
       });
@@ -68,6 +68,12 @@ suite('Lexer', () => {
       Object.defineProperty(exports, 'e', {
         get () {
           return external;
+        }
+      });
+
+      Object.defineProperty(exports, "f", {
+        get: functionget () {
+          return q['p' ];
         }
       });
     `);


### PR DESCRIPTION
This updates the detection of getter named exports to support named getter functions like:

```js
Object.defineProperty(exports, "a", {
  enumerable: true,
  get: function get() {
    return _asdf.a;
  }
});
```

where the getter is both the `get` property and also has a function name since Babel always gives these functions this name in the emit.