### PR TITLE
Individually track unsafe getters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ lib/lexer.wasm: include-wasm/cjs-module-lexer.h src/lexer.c
 	@mkdir -p lib
 	../wasi-sdk-11.0/bin/clang src/lexer.c -I include-wasm --sysroot=../wasi-sdk-11.0/share/wasi-sysroot -o lib/lexer.wasm -nostartfiles \
 	-Wl,-z,stack-size=13312,--no-entry,--compress-relocations,--strip-all,--export=__heap_base,\
-	--export=parseCJS,--export=sa,--export=e,--export=re,--export=es,--export=ee,--export=rre,--export=ree,--export=res,--export=ree \
+	--export=parseCJS,--export=sa,--export=e,--export=re,--export=es,--export=ee,--export=rre,--export=ree,--export=res,--export=ru,--export=us,--export=ue \
 	-Wno-logical-op-parentheses -Wno-parentheses \
 	-Oz
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ EXPORTS_SPREAD: `...` (IDENTIFIER | REQUIRE)
 
 EXPORTS_MEMBER: EXPORTS_DOT_ASSIGN | EXPORTS_LITERAL_COMPUTED_ASSIGN
 
-EXPORTS_DEFINE: `Object` `.` `defineProperty `(` IDENTIFIER_STRING `, {`
+EXPORTS_DEFINE: `Object` `.` `defineProperty `(` EXPORTS_IDENFITIER `,` IDENTIFIER_STRING
+
+EXPORTS_DEFINE_VALUE: EXPORTS_DEFINE `, {`
   (`enumerable: true,`)?
   (
     `value:` |
@@ -121,7 +123,9 @@ EXPORT_STAR_LIB: `Object.keys(` IDENTIFIER$1 `).forEach(function (` IDENTIFIER$2
 
 Spacing between tokens is taken to be any ECMA-262 whitespace, ECMA-262 block comment or ECMA-262 line comment.
 
-* The returned export names are taken to be the combination of the `IDENTIFIER` and `IDENTIFIER_STRING` slots for all `EXPORTS_MEMBER`, `EXPORTS_LITERAL` and `EXPORTS_DEFINE` matches.
+* The returned export names are taken to be the combination of:
+  1. All `IDENTIFIER` and `IDENTIFIER_STRING` slots for `EXPORTS_MEMBER` and `EXPORTS_LITERAL` matches.
+  2. The first `IDENTIFIER_STRING` slot for all `EXPORTS_DEFINE_VALUE` matches where that same string is not an `EXPORTS_DEFINE` match that is not also an `EXPORTS_DEFINE_VALUE` match.
 * The reexport specifiers are taken to be the the combination of:
   1. The `REQUIRE` matches of the last matched of either `MODULE_EXPORTS_ASSIGN` or `EXPORTS_LITERAL`.
   2. All _top-level_ `EXPORT_STAR` `REQUIRE` matches and `EXPORTS_ASSIGN` matches whose `IDENTIFIER` also matches the first `IDENTIFIER` in `EXPORT_STAR_LIB`.
@@ -162,6 +166,8 @@ It will in turn underclassify in cases where the identifiers are renamed:
 })(exports);
 ```
 
+#### Getter Exports Parsing
+
 `Object.defineProperty` is detected for specifically value and getter forms returning an identifier or member expression:
 
 ```js
@@ -186,6 +192,24 @@ Object.defineProperty(exports, 'c', {
 });
 Object.defineProperty(exports, 'd', { value: 'd' });
 Object.defineProperty(exports, '__esModule', { value: true });
+```
+
+To avoid matching getters that have side effects, any getter for an export name that does not support the forms above will
+opt-out of the getter matching:
+
+```js
+// DETECTS: NO EXPORTS
+Object.defineProperty(exports, 'a', {
+  value: 'no problem'
+});
+
+if (false) {
+  Object.defineProperty(module.exports, 'a', {
+    get () {
+      return dynamic();
+    }
+  })
+}
 ```
 
 Alternative object definition structures or getter function bodies are not detected:
@@ -337,63 +361,63 @@ JS Build:
 
 ```
 Module load time
-> 5ms
+> 4ms
 Cold Run, All Samples
 test/samples/*.js (3635 KiB)
-> 323ms
+> 299ms
 
 Warm Runs (average of 25 runs)
 test/samples/angular.js (1410 KiB)
-> 14.84ms
+> 13.96ms
 test/samples/angular.min.js (303 KiB)
-> 4.8ms
+> 4.72ms
 test/samples/d3.js (553 KiB)
-> 7.84ms
+> 6.76ms
 test/samples/d3.min.js (250 KiB)
 > 4ms
 test/samples/magic-string.js (34 KiB)
-> 0.72ms
+> 0.64ms
 test/samples/magic-string.min.js (20 KiB)
-> 0.4ms
+> 0ms
 test/samples/rollup.js (698 KiB)
-> 9.32ms
+> 8.48ms
 test/samples/rollup.min.js (367 KiB)
-> 6.52ms
+> 5.36ms
 
 Warm Runs, All Samples (average of 25 runs)
 test/samples/*.js (3635 KiB)
-> 44ms
+> 40.28ms
 ```
 
 Wasm Build:
 ```
 Module load time
-> 11ms
+> 10ms
 Cold Run, All Samples
 test/samples/*.js (3635 KiB)
-> 42ms
+> 43ms
 
 Warm Runs (average of 25 runs)
 test/samples/angular.js (1410 KiB)
-> 9.92ms
+> 9.32ms
 test/samples/angular.min.js (303 KiB)
-> 3.2ms
+> 3.16ms
 test/samples/d3.js (553 KiB)
-> 5.2ms
+> 5ms
 test/samples/d3.min.js (250 KiB)
-> 2.52ms
+> 2.32ms
 test/samples/magic-string.js (34 KiB)
 > 0.16ms
 test/samples/magic-string.min.js (20 KiB)
-> 0.04ms
+> 0ms
 test/samples/rollup.js (698 KiB)
-> 6.44ms
+> 6.28ms
 test/samples/rollup.min.js (367 KiB)
-> 3.96ms
+> 3.6ms
 
 Warm Runs, All Samples (average of 25 runs)
 test/samples/*.js (3635 KiB)
-> 30.48ms
+> 27.76ms
 ```
 
 ### Wasm Build Steps

--- a/bench/index.mjs
+++ b/bench/index.mjs
@@ -31,7 +31,7 @@ Promise.resolve().then(async () => {
 	console.log('Module load time');
 	{
 		const start = process.hrtime.bigint();
-		var { default: parse } = await import('../lexer.js');
+		var { parse } = await import('../lexer.js');
 		console.log(`> ${c.bold.green(Math.round(Number(process.hrtime.bigint() - start) / 1e6) + 'ms')}`);
 	}
 

--- a/include/cjs-module-lexer.h
+++ b/include/cjs-module-lexer.h
@@ -27,7 +27,7 @@ typedef struct StarExportBinding StarExportBinding;
 
 void bail (uint32_t err);
 
-bool parseCJS (uint16_t* source, uint32_t sourceLen, void (*addExport)(const uint16_t*, const uint16_t*), void (*addReexport)(const uint16_t*, const uint16_t*), void (*clearReexports)());
+bool parseCJS (uint16_t* source, uint32_t sourceLen, void (*addExport)(const uint16_t*, const uint16_t*), void (*addReexport)(const uint16_t*, const uint16_t*), void (*addUnsafeGetter)(const uint16_t*, const uint16_t*), void (*clearReexports)());
 
 enum RequireType {
   Import,

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -18,15 +18,18 @@ export function parse (source, name = '@') {
   const addr = wasm.sa(len);
   (isLE ? copyLE : copyBE)(source, new Uint16Array(wasm.memory.buffer, addr, len));
 
-  if (!wasm.parseCJS(addr, source.length, 0, 0))
+  if (!wasm.parseCJS(addr, source.length, 0, 0, 0))
     throw Object.assign(new Error(`Parse error ${name}${wasm.e()}:${source.slice(0, wasm.e()).split('\n').length}:${wasm.e() - source.lastIndexOf('\n', wasm.e() - 1)}`), { idx: wasm.e() });
 
-  let exports = new Set(), reexports = new Set();
+  let exports = new Set(), reexports = new Set(), unsafeGetters = new Set();
+  
   while (wasm.rre())
     reexports.add(source.slice(wasm.res(), wasm.ree()));
+  while (wasm.ru())
+    unsafeGetters.add(source.slice(wasm.us(), wasm.ue()));
   while (wasm.re()) {
     let exptStr = source.slice(wasm.es(), wasm.ee());
-    if (!strictReserved.has(exptStr))
+    if (!strictReserved.has(exptStr) && !unsafeGetters.has(exptStr))
       exports.add(exptStr);
   }
 

--- a/test/_unit.js
+++ b/test/_unit.js
@@ -16,6 +16,28 @@ async function loadParser () {
 suite('Lexer', () => {
   beforeEach(async () => await loadParser());
 
+  test('Getter opt-outs', () => {
+    var { exports } = parse(`
+      Object.defineProperty(exports, 'a', {
+        enumerable: true,
+        get: function () {
+          return q.p;
+        }
+      });
+
+      if (false) {
+        Object.defineProperty(exports, 'a', {
+          enumerable: false,
+          get: function () {
+            return dynamic();
+          }
+        });
+      }
+    `);
+
+    assert.equal(exports.length, 0);
+  });
+
   test('TypeScript reexports', () => {
     var { exports, reexports } = parse(`
       "use strict";


### PR DESCRIPTION
This updates the getter parsing to specifically track unsafe getters to ensure they are never emitted.

This happens for example in pg with:

```js
 Object.defineProperty(module.exports, 'native', {
    configurable: true,
    enumerable: false,
    get() {
      var native = null
      try {
        native = new PG(require('./native'))
      } catch (err) {
        if (err.code !== 'MODULE_NOT_FOUND') {
          throw err
        }
        /* eslint-disable no-console */
        console.error(err.message)
        /* eslint-enable no-console */
      }

      // overwrite module.exports.native so that getter is never called again
      Object.defineProperty(module.exports, 'native', {
        value: native,
      })

      return native
    },
  })
```

where the internal `defineProperty` with a value definition to do the replacement after the getter has been called is seen as a safe getter so the export is emitted.

Instead we define an unsafe getter to mean any getter definition which does not fit one of the safe determined patterns. Once there is an unsafe definition for a given export name, it will never be emitted as an export even if there is a subsequent safe emission pattern.