### PR TITLE
fix(TypeScript): Expose `Exports` interface type

### DIFF
--- a/lexer.d.ts
+++ b/lexer.d.ts
@@ -1,9 +1,7 @@
-interface Exports {
+export interface Exports {
   exports: string[];
   reexports: string[];
 }
 
 export declare function parse(source: string, name?: string): Exports;
 export declare function init(): Promise<void>;
-
-export {};


### PR DESCRIPTION
This makes it possible to do the following in **TypeScript** code:

```ts
import type { Exports } from "cjs-module-lexer";
```
