### PR TITLE
Add test for other babel reexport checks

### DIFF
--- a/test/_unit.js
+++ b/test/_unit.js
@@ -322,11 +322,36 @@ suite('Lexer', () => {
           exports[x] = notexternal17[x];
         });
       }
-      
+
+      // Babel ??
+      {
+        var _p = require("p");
+        Object.keys(_p).forEach(function (key) {
+          if (key === "default" || key === "__esModule") return;
+          if (key in exports && exports[key] === _p[key]) return;
+          Object.defineProperty(exports, key, {
+            enumerable: true,
+            get: function () {
+              return _p[key];
+            }
+          });
+        });
+      }
+
+      // Babel ??
+      {
+        var _z = require("z");
+
+        Object.keys(_z).forEach(function (key) {
+          if (key === "default" || key === "__esModule") return;
+          if (key in exports && exports[key] === _z[key]) return;
+          exports[key] = _z[key];
+        });
+      }
     `);
     assert.equal(exports.length, 1);
     assert.equal(exports[0], '__esModule');
-    assert.equal(reexports.length, 12);
+    assert.equal(reexports.length, 14);
     assert.equal(reexports[0], 'external');
     assert.equal(reexports[1], 'external2');
     assert.equal(reexports[2], 'external001');
@@ -339,6 +364,8 @@ suite('Lexer', () => {
     assert.equal(reexports[9], 'e5');
     assert.equal(reexports[10], 'e6');
     assert.equal(reexports[11], 'external𤭢');
+    assert.equal(reexports[12], 'p');
+    assert.equal(reexports[13], 'z');
   });
 
   test('invalid exports cases', () => {

--- a/test/_unit.js
+++ b/test/_unit.js
@@ -323,7 +323,7 @@ suite('Lexer', () => {
         });
       }
 
-      // Babel ??
+      // Babel 7.13.10
       {
         var _p = require("p");
         Object.keys(_p).forEach(function (key) {
@@ -338,7 +338,7 @@ suite('Lexer', () => {
         });
       }
 
-      // Babel ??
+      // Babel 7.13.10
       {
         var _z = require("z");
 


### PR DESCRIPTION
I was just testing out star exports on the Babel repl, and noticed these two cases likely also aren't yet supported.

I wonder how many other variations we're missing from past versions!

// cc @nicolo-ribaudo