### PR TITLE
Filter to valid surrogate pairs

### DIFF
--- a/lexer.js
+++ b/lexer.js
@@ -55,7 +55,18 @@ function parseCJS (source, name = '@') {
 function decode (name) {
   if (name[0] === '"' || name[0] === "'") {
     try {
-      return (0, eval)(name);
+      const decoded = (0, eval)(name);
+      let expectSurrogate = false;
+      for (let i = 0; i < decoded.length; i++) {
+        const surrogatePrefix = decoded.charCodeAt(i) & 0xFC00;
+        if (!expectSurrogate && surrogatePrefix !== 0xDC00 && surrogatePrefix !== 0xD800)
+          continue;
+        if (expectSurrogate && surrogatePrefix !== 0xDC00 || !expectSurrogate && surrogatePrefix !== 0xD800)
+          return;
+        expectSurrogate = !expectSurrogate;
+      }
+      if (!expectSurrogate)
+        return decoded;
     }
     catch {}
   }

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -41,18 +41,24 @@ function decode (str) {
   if (str[0] === '"' || str[0] === '\'') {
     try {
       const decoded = (0, eval)(str);
-      // Filter to exclude non-matching UTF16 surrogate strings
-      let expectSurrogate = false;
+      // Filter to exclude non-matching UTF-16 surrogate strings
       for (let i = 0; i < decoded.length; i++) {
         const surrogatePrefix = decoded.charCodeAt(i) & 0xFC00;
-        if (!expectSurrogate && surrogatePrefix !== 0xDC00 && surrogatePrefix !== 0xD800)
+        if (surrogatePrefix < 0xD800) {
+          // Not a surrogate
           continue;
-        if (expectSurrogate && surrogatePrefix !== 0xDC00 || !expectSurrogate && surrogatePrefix !== 0xD800)
+        }
+        else if (surrogatePrefix === 0xD800) {
+          // Validate surrogate pair
+          if ((decoded.charCodeAt(++i) & 0xFC00) !== 0xDC00)
+            return;
+        }
+        else {
+          // Out-of-range surrogate code (above 0xD800)
           return;
-        expectSurrogate = !expectSurrogate;
+        }
       }
-      if (!expectSurrogate)
-        return decoded;
+      return decoded;
     }
     catch {}
   }

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -40,7 +40,19 @@ export function parse (source, name = '@') {
 function decode (str) {
   if (str[0] === '"' || str[0] === '\'') {
     try {
-      return (0, eval)(str);
+      const decoded = (0, eval)(str);
+      // Filter to exclude non-matching UTF16 surrogate strings
+      let expectSurrogate = false;
+      for (let i = 0; i < decoded.length; i++) {
+        const surrogatePrefix = decoded.charCodeAt(i) & 0xFC00;
+        if (!expectSurrogate && surrogatePrefix !== 0xDC00 && surrogatePrefix !== 0xD800)
+          continue;
+        if (expectSurrogate && surrogatePrefix !== 0xDC00 || !expectSurrogate && surrogatePrefix !== 0xD800)
+          return;
+        expectSurrogate = !expectSurrogate;
+      }
+      if (!expectSurrogate)
+        return decoded;
     }
     catch {}
   }

--- a/test/_unit.js
+++ b/test/_unit.js
@@ -494,7 +494,6 @@ suite('Lexer', () => {
       'ab cd',
       'not identifier',
       '\u{D83C}\u{DF10}',
-      '\u{D83C}',
       '\'',
       '@notidentifier',
       '%notidentifier',


### PR DESCRIPTION
This adds filtering to ensure that string encodings always correspond to valid surrogate pairs so that only valid UTF-8 codepoints are represented.